### PR TITLE
Fixed issue with EmailMessage admin without any events

### DIFF
--- a/sendgrid/admin.py
+++ b/sendgrid/admin.py
@@ -170,10 +170,14 @@ class EmailMessageAdmin(admin.ModelAdmin):
 		return emailMessage.categories.count()
 
 	def first_event_type(self, emailMessage):
-		return emailMessage.first_event.event_type.name
+		if emailMessage.first_event:
+			return emailMessage.first_event.event_type.name
+		return None
 
 	def latest_event_type(self, emailMessage):
-		return emailMessage.latest_event.event_type.name
+		if emailMessage.latest_event:
+			return emailMessage.latest_event.event_type.name
+		return None
 
 	def unique_argument_count(self, emailMessage):
 		return emailMessage.uniqueargument_set.count()


### PR DESCRIPTION
There can be cases where no events are mapped against an EmailMessage, either because of delay in receiving the webhook or network errors. Admin change list page for EmailMessage was breaking for such case.

This PR fixes it.
