### PR TITLE
Python3 integration

### DIFF
--- a/sendgrid/backends.py
+++ b/sendgrid/backends.py
@@ -17,21 +17,21 @@ def check_settings(fail_silently=False):
 	Checks that the required settings are available.
 	"""
 	allOk = True
-	
+
 	checks = {
 		"SENDGRID_EMAIL_HOST": SENDGRID_EMAIL_HOST,
 		"SENDGRID_EMAIL_PORT": SENDGRID_EMAIL_PORT,
 		"SENDGRID_EMAIL_USERNAME": SENDGRID_EMAIL_USERNAME,
 		"SENDGRID_EMAIL_PASSWORD": SENDGRID_EMAIL_PASSWORD,
 	}
-	
-	for key, value in checks.iteritems():
+
+	for key, value in checks.items():
 		if not value:
 			logger.warn("{k} is not set".format(k=key))
 			allOk = False
 			if not fail_silently:
 				raise ImproperlyConfigured("{k} was not found".format(k=key))
-			
+
 	return allOk
 
 

--- a/sendgrid/mail.py
+++ b/sendgrid/mail.py
@@ -5,7 +5,7 @@ from django.core.mail import get_connection
 from django.core.mail import send_mail
 
 # django-sendgrid
-from utils import in_test_environment
+from .utils import in_test_environment
 
 
 SENDGRID_EMAIL_BACKEND = getattr(settings, "SENDGRID_EMAIL_BACKEND", None)
@@ -20,10 +20,10 @@ def get_sendgrid_connection(*args, **kwargs):
 	if in_test_environment():
 		logger.debug("In test environment!")
 		backend = "django.core.mail.backends.locmem.EmailBackend"
-		
+
 	logger.debug("Getting SendGrid connection using backend {b}".format(b=backend))
 	sendgrid_connection = get_connection(backend, *args, **kwargs)
-	
+
 	return sendgrid_connection
 
 def send_sendgrid_mail(subject, message, from_email, recipient_list,
@@ -40,6 +40,6 @@ def send_mass_sendgrid_mail(datatuple, fail_silently=False, auth_user=None, auth
 	Sends mass mail with SendGrid.
 	"""
 	raise NotImplementedError
-	
+
 	sendgrid_connection = get_sendgrid_connection()
 	return send_mass_mail(datatuple, fail_silently, auth_password, auth_password, connection=sendgrid_connection)

--- a/sendgrid/mixins.py
+++ b/sendgrid/mixins.py
@@ -4,9 +4,9 @@ try:
 except ImportError:
 	from django.utils import simplejson as json
 
-from utils import add_unsubscribes
-from utils import delete_unsubscribes
-from utils import get_unsubscribes
+from .utils import add_unsubscribes
+from .utils import delete_unsubscribes
+from .utils import get_unsubscribes
 
 
 SENDGRID_EMAIL_USERNAME = getattr(settings, "SENDGRID_EMAIL_USERNAME", None)
@@ -24,7 +24,7 @@ class SendGridUserMixin:
 		response = get_unsubscribes(email=self.email)
 		results = json.loads(response)
 		return len(results) > 0
-		
+
 	def add_to_unsubscribes(self):
 		"""
 		Adds the ``User``.``email`` from the unsubscribe list.
@@ -32,7 +32,7 @@ class SendGridUserMixin:
 		response = add_unsubscribes(email=self.email)
 		result = json.loads(response)
 		return result
-		
+
 	def delete_from_unsubscribes(self):
 		"""
 		Removes the ``User``.``email`` from the unsubscribe list.

--- a/sendgrid/models.py
+++ b/sendgrid/models.py
@@ -8,6 +8,7 @@ from django.core.exceptions import MultipleObjectsReturned
 from django.db import models
 from django.dispatch import receiver
 from django.utils.translation import ugettext_lazy as _
+from six import string_types
 
 from .signals import sendgrid_email_sent
 from .signals import sendgrid_event_recieved
@@ -85,7 +86,7 @@ def save_email_message(sender, **kwargs):
 		recipients = getattr(message, "to", None)
 		toEmail = recipients[0]
 		categoryData = message.sendgrid_headers.data.get("category", None)
-		if isinstance(categoryData, basestring):
+		if isinstance(categoryData, string_types):
 			category = categoryData
 			categories = [category]
 		else:
@@ -113,7 +114,7 @@ def save_email_message(sender, **kwargs):
 
 		uniqueArgsData = message.sendgrid_headers.data.get("unique_args", None)
 		if uniqueArgsData:
-			for k, v in uniqueArgsData.iteritems():
+			for k, v in uniqueArgsData.items():
 				argument, argumentCreated = Argument.objects.get_or_create(key=k)
 				if argumentCreated:
 					logger.debug("Argument {a} was created".format(a=argument))
@@ -123,7 +124,7 @@ def save_email_message(sender, **kwargs):
 					data=v,
 				)
 
-		for component, componentModel in COMPONENT_DATA_MODEL_MAP.iteritems():
+		for component, componentModel in COMPONENT_DATA_MODEL_MAP.items():
 			if component in SENDGRID_EMAIL_TRACKING_COMPONENTS:
 				if component == "sendgrid_headers":
 					componentData = message.sendgrid_headers.as_string()

--- a/sendgrid/tests.py
+++ b/sendgrid/tests.py
@@ -26,7 +26,7 @@ from .signals import sendgrid_email_sent
 from .utils import filterutils
 # from .utils import get_email_message
 from .utils import in_test_environment
-from .utils.requestfactory import RequestFactory 
+from .utils.requestfactory import RequestFactory
 from .views import handle_single_event_request
 
 
@@ -48,7 +48,7 @@ class SendGridEventTest(TestCase):
 	def test_event_email_exists(self):
 		event_count = Event.objects.count()
 		post_data = {
-			"message_id": self.email.message_id, 
+			"message_id": self.email.message_id,
 			"email" : self.email.from_email,
 			"event" : "OPEN",
 			}
@@ -98,7 +98,7 @@ class SendGridEventTest(TestCase):
 
 	def test_event_email_doesnt_exist(self):
 		postData = {
-			"message_id": 'a5df', 
+			"message_id": 'a5df',
 			"email" : self.email.to[0],
 			"event" : "OPEN",
 			"category": ["test_category", "another_test_category"],
@@ -116,7 +116,7 @@ class SendGridEventTest(TestCase):
 
 	def test_event_email_doesnt_exist_no_category(self):
 		postData = {
-			"message_id": 'a5df', 
+			"message_id": 'a5df',
 			"email" : self.email.to[0],
 			"event" : "OPEN"
 		}
@@ -132,7 +132,7 @@ class SendGridEmailTest(TestCase):
 		"""
 		email = SendGridEmailMessage()
 		self.assertTrue(email._message_id)
-		
+
 	def test_email_sends_unique_id(self):
 		"""
 		Tests sending a ``SendGridEmailMessage`` adds a ``message_id`` to the unique args.
@@ -140,7 +140,7 @@ class SendGridEmailTest(TestCase):
 		email = SendGridEmailMessage(to=TEST_RECIPIENTS, from_email=TEST_SENDER_EMAIL)
 		email.send()
 		self.assertTrue(email.sendgrid_headers.data["unique_args"]["message_id"])
-		
+
 	def test_unique_args_persist(self):
 		"""
 		Tests that unique args are not lost due to sending adding the ``message_id`` arg.
@@ -154,7 +154,7 @@ class SendGridEmailTest(TestCase):
 		email.sendgrid_headers.setUniqueArgs(uniqueArgs)
 		email.send()
 
-		for k, v in uniqueArgs.iteritems():
+		for k, v in uniqueArgs.items():
 			self.assertEqual(v, email.sendgrid_headers.data["unique_args"][k])
 
 		self.assertTrue(email.sendgrid_headers.data["unique_args"]["message_id"])
@@ -170,7 +170,7 @@ class SendGridEmailTest(TestCase):
 			"""
 			self.assertTrue("response" in kwargs)
 			self.assertTrue("message" in kwargs)
-			
+
 		email = SendGridEmailMessage(to=TEST_RECIPIENTS, from_email=TEST_SENDER_EMAIL)
 		response = email.send()
 
@@ -189,7 +189,7 @@ class SendWithSendGridEmailMessageTest(TestCase):
 		Sets up the tests.
 		"""
 		self.signalsReceived = defaultdict(list)
-		
+
 	def test_send_email_sends_signal(self):
 		"""
 		Tests that sending a ``SendGridEmailMessage`` sends a ``sendgrid_email_sent`` signal.
@@ -201,13 +201,13 @@ class SendWithSendGridEmailMessageTest(TestCase):
 			"""
 			self.signalsReceived["sendgrid_email_sent"].append(1)
 			return True
-			
+
 		email = SendGridEmailMessage(to=TEST_RECIPIENTS, from_email=TEST_SENDER_EMAIL)
 		email.send()
-		
+
 		numEmailSentSignalsRecieved = sum(self.signalsReceived["sendgrid_email_sent"])
 		self.assertEqual(numEmailSentSignalsRecieved, 1)
-		
+
 	def test_send_with_send_mail(self):
 		"""
 		Tests sending an email with the ``send_email_with_sendgrid`` helper.
@@ -227,7 +227,7 @@ class SendWithEmailMessageTest(TestCase):
 		Sets up the tests.
 		"""
 		self.connection = get_sendgrid_connection()
-		
+
 	def test_send_with_email_message(self):
 		"""
 		Tests sending an ``EmailMessage`` with the ``SendGridEmailBackend``.
@@ -246,7 +246,7 @@ class SendWithEmailMessageTest(TestCase):
 class SendWithSendGridEmailMultiAlternativesTest(TestCase):
 	def setUp(self):
 		self.signalsReceived = defaultdict(list)
-		
+
 	def test_send_multipart_email(self):
 		"""
 		Tests sending multipart emails.
@@ -257,7 +257,7 @@ class SendWithSendGridEmailMultiAlternativesTest(TestCase):
 		msg = SendGridEmailMultiAlternatives(subject, text_content, from_email, [to])
 		msg.attach_alternative(html_content, "text/html")
 		msg.send()
-		
+
 	def test_send_multipart_email_sends_signal(self):
 		@receiver(sendgrid_email_sent)
 		def receive_sendgrid_email_sent(*args, **kwargs):
@@ -266,10 +266,10 @@ class SendWithSendGridEmailMultiAlternativesTest(TestCase):
 			"""
 			self.signalsReceived["sendgrid_email_sent"].append(1)
 			return True
-			
+
 		email = SendGridEmailMultiAlternatives(to=TEST_RECIPIENTS, from_email=TEST_SENDER_EMAIL)
 		email.send()
-		
+
 		numEmailSentSignalsRecieved = sum(self.signalsReceived["sendgrid_email_sent"])
 		self.assertEqual(numEmailSentSignalsRecieved, 1)
 
@@ -281,7 +281,7 @@ class FilterUtilsTests(TestCase):
 		Set up the tests.
 		"""
 		pass
-		
+
 	def test_validate_filter_spec(self):
 		"""
 		Tests validation of a filter specification.
@@ -295,7 +295,7 @@ class FilterUtilsTests(TestCase):
 			},
 		}
 		self.assertEqual(validate_filter_specification(filterSpec), True)
-		
+
 	def test_subscriptiontrack_enable_parameter(self):
 		"""
 		Tests the ``subscriptiontrack`` filter's ``enable`` paramter.
@@ -308,7 +308,7 @@ class FilterUtilsTests(TestCase):
 		self.assertEqual(validate_filter_setting_value("subscriptiontrack", "enable", "1"), True)
 		self.assertEqual(validate_filter_setting_value("subscriptiontrack", "enable", "0.0"), False)
 		self.assertEqual(validate_filter_setting_value("subscriptiontrack", "enable", "1.0"), False)
-		
+
 	def test_opentrack_enable_parameter(self):
 		"""
 		Tests the ``opentrack`` filter's ``enable`` paramter.
@@ -328,7 +328,7 @@ class UpdateFiltersTests(TestCase):
 	def setUp(self):
 		"""docstring for setUp"""
 		self.email = SendGridEmailMessage(to=TEST_RECIPIENTS, from_email=TEST_SENDER_EMAIL)
-		
+
 	def test_update_filters(self):
 		"""
 		Tests SendGrid filter functionality.
@@ -504,7 +504,7 @@ class EventTypeFixtureTests(TestCase):
 		}
 
 	def test_event_types_exists(self):
-		for name, primaryKey in self.expectedEventTypes.iteritems():
+		for name, primaryKey in self.expectedEventTypes.items():
 			self.assertEqual(
 				EventType.objects.get(pk=primaryKey),
 				EventType.objects.get(name=name)
@@ -522,7 +522,7 @@ class DownloadAttachmentTestCase(TestCase):
 		emailMessage = SendGridEmailMessage(
 			to=TEST_RECIPIENTS,
 			from_email=TEST_SENDER_EMAIL)
-		for name, contents in self.attachments.iteritems():
+		for name, contents in self.attachments.items():
 			emailMessage.attach(name, contents)
 
 		response = emailMessage.send()

--- a/sendgrid/utils/__init__.py
+++ b/sendgrid/utils/__init__.py
@@ -10,7 +10,7 @@ try:
 	import cStringIO as StringIO
 except ImportError:
 	try:
-		from StringIO import StringIO
+		import StringIO
 	except ImportError:
 		from io import StringIO
 

--- a/sendgrid/utils/__init__.py
+++ b/sendgrid/utils/__init__.py
@@ -9,7 +9,11 @@ except ImportError:
 try:
 	import cStringIO as StringIO
 except ImportError:
-	import StringIO
+	try:
+		from StringIO import StringIO
+	except ImportError:
+		from io import StringIO
+
 
 
 from django.conf import settings

--- a/sendgrid/utils/__init__.py
+++ b/sendgrid/utils/__init__.py
@@ -1,5 +1,4 @@
 import datetime
-import httplib
 import logging
 import time
 import urllib

--- a/sendgrid/utils/__init__.py
+++ b/sendgrid/utils/__init__.py
@@ -3,7 +3,10 @@ import httplib
 import logging
 import time
 import urllib
-import urllib2
+try:
+	import urllib.request as urllib2
+except ImportError:
+	import urllib2
 try:
 	import cStringIO as StringIO
 except ImportError:
@@ -46,11 +49,11 @@ def remove_keys_without_value(d):
 	Removes all key-value pairs with empty values.
 	"""
 	dCopy = d.copy()
-	
-	delKeys = [k for k, v in dCopy.iteritems() if not v]
+
+	delKeys = [k for k, v in dCopy.items() if not v]
 	for k in delKeys:
 		del dCopy[k]
-		
+
 	return dCopy
 
 def normalize_parameters(d):
@@ -58,14 +61,14 @@ def normalize_parameters(d):
 	Normalizes the parameters, adds authorization details and removes empty entries.
 	"""
 	dCopy = d.copy()
-	
+
 	authorization = {
 		"api_user": SENDGRID_EMAIL_USERNAME,
 		"api_key": SENDGRID_EMAIL_PASSWORD,
 	}
 	dCopy.update(authorization)
 	dCopy = remove_keys_without_value(dCopy)
-	
+
 	return dCopy
 
 def get_unsubscribes(date=None, days=None, start_date=None, end_date=None, limit=None, offset=None, email=None):
@@ -73,17 +76,17 @@ def get_unsubscribes(date=None, days=None, start_date=None, end_date=None, limit
 	Returns a list of unsubscribes with addresses and optionally with dates.
 	"""
 	ENDPOINT = "https://sendgrid.com/api/unsubscribes.get.json"
-	
+
 	if days and (start_date or end_date):
 		raise AttributeError
-		
+
 	if days:
 		if start_date or end_date:
 			raise AttributeError
 	elif start_date and end_date:
 		if days:
 			raise AttributeError
-			
+
 	parameters = {
 		"date": date,
 		"days": days,
@@ -94,7 +97,7 @@ def get_unsubscribes(date=None, days=None, start_date=None, end_date=None, limit
 		"email": email,
 	}
 	parameters = normalize_parameters(parameters)
-	
+
 	data = urllib.urlencode(parameters)
 	request = urllib2.Request(ENDPOINT, data)
 	response = urllib2.urlopen(request)
@@ -107,12 +110,12 @@ def add_unsubscribes(email):
 	Add email addresses to the Unsubscribe list.
 	"""
 	ENDPOINT = "https://sendgrid.com/api/unsubscribes.add.json"
-	
+
 	parameters = {
 		"email": email,
 	}
 	parameters = normalize_parameters(parameters)
-	
+
 	data = urllib.urlencode(parameters)
 	request = urllib2.Request(ENDPOINT, data)
 	response = urllib2.urlopen(request)
@@ -125,7 +128,7 @@ def delete_unsubscribes(email, start_date=None, end_date=None):
 	Delete an address from the Unsubscribe list. Please note that if no parameters are provided the ENTIRE list will be removed.
 	"""
 	ENDPOINT = "https://sendgrid.com/api/unsubscribes.delete.json"
-	
+
 	if not ((start_date and end_date) or email):
 		raise Exception("You're about to delete the entire list!")
 
@@ -135,7 +138,7 @@ def delete_unsubscribes(email, start_date=None, end_date=None):
 		"email": email,
 	}
 	parameters = normalize_parameters(parameters)
-	
+
 	data = urllib.urlencode(parameters)
 	request = urllib2.Request(ENDPOINT, data)
 	response = urllib2.urlopen(request)
@@ -156,7 +159,7 @@ def zip_files(files):
 
 	buffer = StringIO.StringIO()
 	with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zio:
-		for name, content in files.iteritems():
+		for name, content in files.items():
 			zio.writestr(name, content)
 		buffer.flush()
 

--- a/sendgrid/utils/filterutils.py
+++ b/sendgrid/utils/filterutils.py
@@ -29,10 +29,10 @@ def validate_filter_setting_value(filter, setting, value, ignoreMissingTests=IGN
 	"""
 	if filter not in INTERFACES:
 		raise AttributeError("The filter {f} is not valid".format(f=filter))
-		
+
 	if setting not in INTERFACES[filter]:
 		raise AttributeError("The setting {s} is not valid for the filter {f}".format(s=setting, f=filter))
-		
+
 	testName = ".".join([filter, setting])
 	try:
 		test = FILTER_SETTING_VALUE_TESTS[testName]
@@ -43,7 +43,7 @@ def validate_filter_setting_value(filter, setting, value, ignoreMissingTests=IGN
 			raise e
 	else:
 		result = test(value)
-		
+
 	return result
 
 def validate_filter_specification(f):
@@ -53,8 +53,8 @@ def validate_filter_specification(f):
 	passedAllTests = None
 
 	testResults = {}
-	for filter, spec in f.iteritems():
-		for setting, value in spec.iteritems():
+	for filter, spec in f.items():
+		for setting, value in spec.items():
 			testKey = ".".join([filter, setting])
 			testResult = validate_filter_setting_value(filter, setting, value)
 			testResults[testKey] = testResult
@@ -71,9 +71,9 @@ def update_filters(email, filterSpec, validate=VALIDATE_FILTER_SPECIFICATION):
 		filterSpecIsValid = validate_filter_specification(filterSpec)
 		if not filterSpecIsValid:
 			raise Exception("Invalid filter specification")
-			
-	for filter, spec in filterSpec.iteritems():
-		for setting, value in spec.iteritems():
+
+	for filter, spec in filterSpec.items():
+		for setting, value in spec.items():
 			email.sendgrid_headers.addFilterSetting(fltr=filter, setting=setting, val=value)
 
 	return


### PR DESCRIPTION
refs: https://github.com/RyanBalfanz/django-sendgrid/issues/73
My project is Python3.
So I fixed some compatibility below.

---

`dict.iteritems` to `dict.items`

`import urllib2`
to

```
try:
    import urllib.request as urllib2
except ImportError:
    import urllib2
```

`import simplejson as json`
to

```
try:
    import simplejson as json
except ImportError:
    import json
```

`isinstance(categoryData, basestring):`
to

```
from six import string_types
isinstance(categoryData, string_types)
```

`import StringIO`
to

```
try:
    import StringIO
except ImportError:
    from io import StringIO
```

remove unused `import httplib`

remove some `.` and spaces.

https://github.com/RyanBalfanz/django-sendgrid/pull/76/files?w=
(diff without spaces)
